### PR TITLE
Fix support for bbb version 2.2.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 bbb_apt_repo_url: 'https://ubuntu.bigbluebutton.org/xenial-220/'
 bbb_ubuntu_version: "16.04"
+bbb_install_html5: True
+bbb_install_playback_notes: True
+bbb_install_playback_podcast: True
+bbb_install_playback_screenshare: True
 bbb_install_demo: False
 bbb_install_check: False
 bbb_configure_nat: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,15 @@
     - multiverse_repositories
     - repositories
 
+- name: Check supplemental PPA repos are enabled
+  apt_repository: repo={{ item }} state=present
+  with_items:
+    - 'ppa:bigbluebutton/support'
+    - 'ppa:rmescandon/yq'
+  tags:
+    - ppa-repositories
+    - repositories
+
 - name: Check BigBlueButton repo is enabled
   apt_repository: repo={{ item }} state=present
   with_items:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,6 +127,24 @@
   tags:
     - install_bbb-html5
 
+- name: Install notes playback package
+  apt: name=bbb-playback-notes state=present
+  when: bbb_install_playback_notes == True
+  tags:
+    - install_bbb-playback-notes
+
+- name: Install podcast playback package
+  apt: name=bbb-playback-podcast state=present
+  when: bbb_install_playback_podcast == True
+  tags:
+    - install_bbb-playback-podcast
+
+- name: Install screenshare playback package
+  apt: name=bbb-playback-screenshare state=present
+  when: bbb_install_playback_screenshare == True
+  tags:
+    - install_bbb-playback-screenshare
+
 - name: Install bbb-demo package
   apt: name=bbb-demo state=present
   when: bbb_install_demo == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,6 +86,47 @@
   tags:
     - install_bbb
 
+- name: Check MongoDB apt key is present
+  apt_key:
+    url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+    state: present
+  when: bbb_install_html5 == True
+  tags:
+    - mongodb-apt_key
+
+- name: Check MongoDB repo is enabled
+  apt_repository: repo="deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" state=present
+  when: bbb_install_html5 == True
+  tags:
+    - mongodb-repositories
+    - repositories
+
+- name: Check NodeJS apt key is present
+  apt_key:
+    url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+    state: present
+  when: bbb_install_html5 == True
+  tags:
+    - nodejs-apt_key
+
+- name: Check NodeJS repo is enabled
+  apt_repository: repo="deb https://deb.nodesource.com/node_8.x xenial main" state=present
+  when: bbb_install_html5 == True
+  tags:
+    - nodejs-repositories
+    - repositories
+- name: Install bbb-html5 and dependencies
+  apt:
+    name:
+      - bbb-html5
+      - mongodb-org
+      - curl
+      - nodejs
+    state: present
+  when: bbb_install_html5 == True
+  tags:
+    - install_bbb-html5
+
 - name: Install bbb-demo package
   apt: name=bbb-demo state=present
   when: bbb_install_demo == True

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -43,7 +43,7 @@
 
 - name: Update http for https on BigBlueButton webapp
   replace:
-    path: /var/lib/tomcat7/webapps/bigbluebutton/WEB-INF/classes/bigbluebutton.properties
+    path: "/usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties"
     regexp: 'bigbluebutton.web.serverURL=http:'
     replace: 'bigbluebutton.web.serverURL=https:'
     backup: yes

--- a/templates/bbb-ssl.conf.j2
+++ b/templates/bbb-ssl.conf.j2
@@ -3,7 +3,7 @@ server {
   listen [::]:80;
   server_name {{ bbb_server_name }};
   listen 443 ssl;
-  listen [::]:443;
+  listen [::]:443 ssl;
     ssl_certificate /etc/letsencrypt/live/{{ bbb_server_name }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ bbb_server_name }}/privkey.pem;
     ssl_session_cache shared:SSL:10m;


### PR DESCRIPTION
Current bbb requires several additional repositories, has changed the location of some conffiles, and is split into additional packages. With the fixes in this PR applied, running the example playbook yields a working basic installation of bbb 2.2.0.